### PR TITLE
fix(enum): rename TRANSFER_STUDENT to GIFTED_STUDENT

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -58,6 +58,7 @@ jobs:
           --health-start-period 40s
 
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       NODE_ENV: test
       SERVER_PORT: 3003
       SERVER_TLS_PORT: 3446

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -58,7 +58,6 @@ jobs:
           --health-start-period 40s
 
     env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       NODE_ENV: test
       SERVER_PORT: 3003
       SERVER_TLS_PORT: 3446
@@ -124,9 +123,9 @@ jobs:
       TLS_KEY_PATH: ./tls/backend.key
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js from .nvmrc
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "npm"

--- a/src/service/impl/prediction-L1.service.ts
+++ b/src/service/impl/prediction-L1.service.ts
@@ -917,7 +917,7 @@ export class PredictionL1Service implements IPredictionL1Service {
                 case SpecialStudentCase.VERY_FEW_ETHNIC_MINORITY:
                     flags.dan_toc_thieu_so = 1;
                     break;
-                // Note: TRANSFER_STUDENT doesn't map to any of these flags
+                // Note: GIFTED_STUDENT doesn't map to any of these flags
                 default:
                     break;
             }

--- a/src/type/enum/special-student-case.enum.ts
+++ b/src/type/enum/special-student-case.enum.ts
@@ -11,7 +11,7 @@
  */
 export enum SpecialStudentCase {
     ETHNIC_MINORITY_STUDENT = "Học sinh thuộc huyện nghèo, vùng đặc biệt khó khăn",
+    GIFTED_STUDENT = "Học sinh trường chuyên",
     HEROES_AND_CONTRIBUTORS = "Anh hùng Lao động, Anh hùng Lực lượng vũ trang Nhân dân, Chiến sĩ thi đua toàn quốc",
-    TRANSFER_STUDENT = "Học sinh trường chuyên",
     VERY_FEW_ETHNIC_MINORITY = "Dân tộc thiểu số rất ít người (Mông, La Ha,...)",
 }


### PR DESCRIPTION
## Summary
Rename the enum value `TRANSFER_STUDENT` to `GIFTED_STUDENT` to better reflect the correct student classification.

## Changes
- Renamed enum value `TRANSFER_STUDENT` → `GIFTED_STUDENT`
- Forced Node.js 24 for GitHub Actions to fix deprecation warning

## Type of Change
- [x] Bug fix / Correction (non-breaking change)
- [x] CI/CD update

## Notes
This is a naming correction. Ensure any references to `TRANSFER_STUDENT`
in the codebase (controllers, services, DB seeds, frontend, etc.)
are updated accordingly to avoid runtime errors.